### PR TITLE
Add Vue2 config

### DIFF
--- a/configs/vue2.js
+++ b/configs/vue2.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: [
+    require.resolve('./javascript'),
+    'plugin:vue/recommended',
+    'prettier',
+  ],
+  parser: 'vue-eslint-parser',
+}


### PR DESCRIPTION
Based and tested on HQ config. When we implement this we can also get rid of the `@vue/cli-plugin-eslint` making our way to Vite just a bit easier.