### PR TITLE
Add 'vue/component-tags-order' rule

### DIFF
--- a/configs/vue3.js
+++ b/configs/vue3.js
@@ -10,4 +10,12 @@ module.exports = {
     parser: '@typescript-eslint/parser',
   },
   plugins: ['@typescript-eslint', 'vuejs-accessibility'],
+  rules: {
+    'vue/component-tags-order': [
+      'error',
+      {
+        order: ['script', 'template', 'style'],
+      },
+    ],
+  },
 }


### PR DESCRIPTION
This will only allow the following order in Vue3 projects. Decided to only add to Vue3 for now as it would break a lot of Vue2 projects.

```vue
<script>/* ... */</script>
<template>...</template>
<style>/* ... */</style>
```