### PR TITLE
Always self-close html void elements

### DIFF
--- a/configs/vue2.js
+++ b/configs/vue2.js
@@ -8,7 +8,14 @@ module.exports = {
   parser: 'vue-eslint-parser',
   plugins: ['vuejs-accessibility'],
   rules: {
-    'vue/html-self-closing': 'error',
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always',
+        },
+      },
+    ],
     'vue/html-closing-bracket-spacing': 'error',
   },
 }

--- a/configs/vue3.js
+++ b/configs/vue3.js
@@ -17,7 +17,14 @@ module.exports = {
         order: ['script', 'template', 'style'],
       },
     ],
-    'vue/html-self-closing': 'error',
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always',
+        },
+      },
+    ],
     'vue/html-closing-bracket-spacing': 'error',
   },
 }


### PR DESCRIPTION
Prettier doesn't allow html void elements to not be self-closing. See https://github.com/prettier/prettier/issues/5641