### PR TITLE
Move self closing rules back to vue configs to overwrite prettier

### DIFF
--- a/configs/_vue-generic.js
+++ b/configs/_vue-generic.js
@@ -5,15 +5,6 @@ module.exports = {
   ],
   plugins: ['vuejs-accessibility'],
   rules: {
-    'vue/html-self-closing': [
-      'error',
-      {
-        html: {
-          void: 'always',
-        },
-      },
-    ],
-    'vue/html-closing-bracket-spacing': 'error',
     'vue/no-empty-component-block': 'error',
     'vue/html-button-has-type': 'warn',
   },

--- a/configs/vue2.js
+++ b/configs/vue2.js
@@ -5,4 +5,17 @@ module.exports = {
     'prettier',
   ],
   parser: 'vue-eslint-parser',
+  rules: {
+    // Rule not in Vue generic because it has to overwrite prettier.
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always',
+        },
+      },
+    ],
+    // Rule not in Vue generic because it has to overwrite prettier.
+    'vue/html-closing-bracket-spacing': 'error',
+  },
 }

--- a/configs/vue3.js
+++ b/configs/vue3.js
@@ -16,5 +16,16 @@ module.exports = {
         order: ['script', 'template', 'style'],
       },
     ],
+    // Rule not in Vue generic because it has to overwrite prettier.
+    'vue/html-self-closing': [
+      'error',
+      {
+        html: {
+          void: 'always',
+        },
+      },
+    ],
+    // Rule not in Vue generic because it has to overwrite prettier.
+    'vue/html-closing-bracket-spacing': 'error',
   },
 }


### PR DESCRIPTION
Noticed checks failed in 1.6.1 that didn't fail in 1.7.0. 
What happened it that by moving some rules that are overwriting prettier to the vue generic, got overwritten again by prettier.