### PR TITLE
update readme to include proper eslint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To run Eslint on your code, add the following script to your package.json:
 
 ```js
 "scripts": {
-  "lint:js": "eslint . --cache",
+  "lint:js": "eslint . --ext .vue,.js,.ts --cache",
   "lintfix:js": "npm run lint:js -- --fix",
 }
 ```


### PR DESCRIPTION
The currently displayed command to run eslint doesn't do a recursive search of all files in the project, and will only shallowly check for linting errors. 

This PR updates the readme to include a command that works properly.