### PR TITLE
Restore js parserOptions

### DIFF
--- a/configs/javascript.js
+++ b/configs/javascript.js
@@ -8,6 +8,10 @@ module.exports = {
     browser: true,
     node: true,
   },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
   extends: ['eslint:recommended', 'prettier'],
   rules: {
     'no-undefined': 'error',


### PR DESCRIPTION
[These were in javascript.js before](https://github.com/leukeleu/eslint-config/commit/b40496ab669944455077c4f9f3179991cae7f75a), and apparently required for proper linting of at least AcademicTransfer (I get errors about using const/import etc. otherwise)