### PR TITLE
apply prettier rules last to solve conflict

### DIFF
--- a/configs/nuxt2.js
+++ b/configs/nuxt2.js
@@ -6,7 +6,6 @@ module.exports = {
   extends: [
     // Standard JS rules
     'eslint:recommended',
-    'prettier',
 
     // Vue2 rules
     'plugin:vue/recommended',
@@ -14,6 +13,9 @@ module.exports = {
 
     // Nuxt rules
     'plugin:nuxt/recommended',
+
+    // Prettier rules (turns off rules that conflict with Prettier)
+    'prettier',
   ],
   // We don't need to include the vue-eslint-parser here because it's included in the nuxt/recommended config.
 

--- a/configs/nuxt3.js
+++ b/configs/nuxt3.js
@@ -6,7 +6,6 @@ module.exports = {
   extends: [
     // Standard JS rules
     'eslint:recommended',
-    'prettier',
 
     // Vue3 rules
     'plugin:vue/vue3-recommended',
@@ -18,6 +17,9 @@ module.exports = {
 
     // Nuxt rules
     'plugin:nuxt/recommended',
+
+    // Prettier rules (turns off rules that conflict with Prettier)
+    'prettier',
   ],
 
   // We don't need to include the vue-eslint-parser here because it's included in the nuxt/recommended settings

--- a/configs/vue2.js
+++ b/configs/vue2.js
@@ -6,11 +6,13 @@ module.exports = {
   extends: [
     // Standard JS rules
     'eslint:recommended',
-    'prettier',
 
     // Vue2 rules
     'plugin:vue/recommended',
     'plugin:vuejs-accessibility/recommended',
+
+    // Prettier rules (turns off rules that conflict with Prettier)
+    'prettier',
   ],
   parser: 'vue-eslint-parser',
   rules: {

--- a/configs/vue3.js
+++ b/configs/vue3.js
@@ -6,13 +6,15 @@ module.exports = {
   extends: [
     // Standard JS rules
     'eslint:recommended',
-    'prettier',
     // Vue3 rules
     'plugin:vue/vue3-recommended',
     'plugin:vuejs-accessibility/recommended',
     // Typescript rules
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/stylistic',
+
+    // Prettier rules (turns off rules that conflict with Prettier)
+    'prettier',
   ],
   parser: 'vue-eslint-parser',
 


### PR DESCRIPTION
This is necessary to fix some conflicting (auto-)formatting that happens when you run the lint commands.