### PR TITLE
Revert "Use deployer access token"

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.DEPLOYER_ACCESS_TOKEN }}
+          token: ${{ secrets.DEPLOYER_RELEASE_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
Reverts leukeleu/eslint-config#156

Does help with the checkout, but it doesn't allow a push back to this repo